### PR TITLE
Support for wide characters (e.g. kanji and emoji)

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -96,6 +96,7 @@ POSIX = 0
 Term::ReadKey = 2.30
 List::MoreUtils = 0.33
 Sub::Exporter = 0.984
+String::TtyLength = 0.02
 
 [Prereqs / TestRequires]
 Test::More = 0.88 ; The first version with done_testing

--- a/lib/Term/FormatColumns.pm
+++ b/lib/Term/FormatColumns.pm
@@ -10,19 +10,12 @@ use Sub::Exporter -setup => [
     ),
 ];
 
-use Term::ReadKey qw( GetTerminalSize );
-use List::Util qw( max );
-use List::MoreUtils qw( part each_arrayref );
-use POSIX qw( ceil );
-use Symbol qw(qualify_to_ref);
-
-# Find the length of a string as displayed on the terminal, ignoring any ANSI
-# escape sequences.
-sub _term_length {
-    my ( $str ) = @_;
-    $str =~ s/\x1b\[[0-9;]+m//g;
-    return length $str;
-}
+use Term::ReadKey     qw( GetTerminalSize );
+use POSIX             qw( ceil );
+use List::Util        qw( max );
+use List::MoreUtils   qw( part each_arrayref );
+use Symbol            qw( qualify_to_ref );
+use String::TtyLength qw( tty_width );
 
 =sub format_columns
 
@@ -72,7 +65,7 @@ being attached to a known/knowable terminal.
 
 sub format_columns_for_width {
     my ( $term_width, @data ) = @_;
-    my $max_width = max map { _term_length( $_ ) } @data;
+    my $max_width = max map { tty_width( $_ ) } @data;
     $max_width += 2; # make sure at least two spaces between data values
     my $columns = int( $term_width / $max_width );
     if ( $columns <= 1 ) {
@@ -89,7 +82,7 @@ sub format_columns_for_width {
         my @cells = map { $data[$_] } @row_vals;
         my $last_cell = pop @cells;
         for (@cells) {
-            my $length = _term_length( $_ );
+            my $length = tty_width( $_ );
             $output .= $_;
             $output .= ' ' x ($column_width - $length);
         }

--- a/t/format.t
+++ b/t/format.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use Test::More;
 use Term::FormatColumns qw(format_columns_for_width);
+use utf8;
 
 my @data = qw( foo bar baz biz blargh fizzbuzz );
 my $output;
@@ -45,5 +46,29 @@ foo       biz
 bar       blargh
 baz       $bold
 OUTPUT
+
+my @strings = ( "aa", "bb", "cc", "😄😄",
+                "dd", "ee", "ff", "😄😄",
+                "gg", "hh", "ii", "😄😄",
+                "jj", "kk", "ll", "😄😄",
+              );
+$output = format_columns_for_width 40, @strings;
+is $output, <<OUTPUT, 'wide emoji handled correctly';
+aa    😄😄  ff    hh    jj    😄😄
+bb    dd    😄😄  ii    kk    
+cc    ee    gg    😄😄  ll    
+OUTPUT
+
+@strings = (
+                "allow", "bilbo",
+                "こんにちは",
+                "frodo", "snack", "fruit",
+           );
+$output = format_columns_for_width 40, @strings;
+is $output, <<OUTPUT, 'hiragana (wide chars) handled correctly';
+allow        こんにちは   snack
+bilbo        frodo        fruit
+OUTPUT
+
 
 done_testing;


### PR DESCRIPTION
Hi Doug,

After quite a bit of experimentation with various modules, I've got the tty_width() function working as expected (for the characters I've tried it with), including on Win32. All green on CPAN Testers.

I added a couple of simple tests.

At some point over the coming weeks I'll experiment with a broader range of writing systems. I know there are some Unicode characters that are sometimes single width and sometimes double, so I need to learn more about those.
But for now using this function makes this layout better, and improved Text::Table::Tiny as well.

Cheers,
Neil